### PR TITLE
Use shared ViewModel in Fragments

### DIFF
--- a/samples/android-weatherapp-mvvm/app/src/main/kotlin/org/koin/sampleapp/view/result/ResultListFragment.kt
+++ b/samples/android-weatherapp-mvvm/app/src/main/kotlin/org/koin/sampleapp/view/result/ResultListFragment.kt
@@ -9,7 +9,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import kotlinx.android.synthetic.main.fragment_weather_list.*
-import org.koin.android.architecture.ext.viewModel
+import org.koin.android.architecture.ext.sharedViewModel
 import org.koin.sampleapp.R
 import org.koin.sampleapp.model.DailyForecastModel
 
@@ -19,7 +19,7 @@ class ResultListFragment : Fragment() {
 
     val TAG = javaClass.simpleName
 
-    val model: ResultViewModel by viewModel()
+    val model: ResultViewModel by sharedViewModel()
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         return inflater.inflate(R.layout.fragment_weather_list, container, false)

--- a/samples/sampleapp-arch/app/src/main/kotlin/org/koin/sampleapp/di/step5/Fragment_step5.kt
+++ b/samples/sampleapp-arch/app/src/main/kotlin/org/koin/sampleapp/di/step5/Fragment_step5.kt
@@ -26,7 +26,7 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.SeekBar
 import com.example.android.codelabs.lifecycle.R
-import org.koin.android.architecture.ext.viewModel
+import org.koin.android.architecture.ext.sharedViewModel
 
 /**
  * Shows a SeekBar that is synced with a value in a ViewModel.
@@ -35,7 +35,7 @@ class Fragment_step5 : Fragment() {
 
     private var mSeekBar: SeekBar? = null
 
-    val mSeekBarViewModel: SeekBarViewModel by viewModel()
+    val mSeekBarViewModel: SeekBarViewModel by sharedViewModel()
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?,
                               savedInstanceState: Bundle?): View? {


### PR DESCRIPTION
The WeatherApp sample does not work correctly, because the Fragment uses a different ViewModel than the Activity. It seems like it was forgotten to be updated after 0.9.1.
Since the sampleapp-arch was also created before updating to 0.9.1, I guess it was also meant to be used with a shared ViewModel.